### PR TITLE
Investigate TypeScript error on analytics page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "recharts": "^2.8.0",
         "tailwind-merge": "^1.14.0",
         "tailwindcss": "^3.3.0",
-        "typescript": "^5.0.0",
+        "tailwindcss-animate": "^1.0.7",
         "zod": "^3.22.0"
       },
       "devDependencies": {
@@ -60,6 +60,7 @@
         "lint-staged": "^15.0.0",
         "prettier": "^3.0.0",
         "prettier-plugin-tailwindcss": "^0.5.0",
+        "typescript": "^5.8.3",
         "uuid": "^9.0.0"
       },
       "engines": {
@@ -10351,6 +10352,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
     "node_modules/tailwindcss/node_modules/postcss-load-config": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
@@ -10664,6 +10674,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "recharts": "^2.8.0",
     "tailwind-merge": "^1.14.0",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5.0.0",
+    "tailwindcss-animate": "^1.0.7",
     "zod": "^3.22.0"
   },
   "devDependencies": {
@@ -76,6 +76,7 @@
     "lint-staged": "^15.0.0",
     "prettier": "^3.0.0",
     "prettier-plugin-tailwindcss": "^0.5.0",
+    "typescript": "^5.8.3",
     "uuid": "^9.0.0"
   },
   "lint-staged": {

--- a/src/app/(dashboard)/analytics/page.tsx
+++ b/src/app/(dashboard)/analytics/page.tsx
@@ -1,4 +1,4 @@
-import { LineChart, BarChart, PieChart, Activity, ShieldCheck, AlertTriangle } from "lucide-react";
+import { Activity, ShieldCheck, AlertTriangle } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -11,7 +11,7 @@ import {
   ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart";
-import { Bar, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis, Legend, Pie, Cell } from "recharts";
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis, Legend, Pie, PieChart, Cell } from "recharts";
 
 const networkTrafficData = Array.from({ length: 30 }, (_, i) => ({
   date: `2023-11-${String(i + 1).padStart(2, '0')}`,


### PR DESCRIPTION
<!-- Correct chart component imports in analytics page to resolve TypeScript errors. -->

<!-- The analytics page was failing due to `BarChart` and `PieChart` being incorrectly imported from `lucide-react` instead of `recharts`. Additionally, `tailwindcss-animate` was installed to fix subsequent build failures. -->