### PR TITLE
Fix the encountered error

### DIFF
--- a/src/ai/flows/get-system-overview.ts
+++ b/src/ai/flows/get-system-overview.ts
@@ -46,7 +46,9 @@ const getSystemOverviewFlow = ai.defineFlow(
     outputSchema: GetSystemOverviewOutputSchema,
   },
   async () => {
-    const {output} = await prompt();
+    const {output} = await prompt({
+      model: 'googleai/gemini-1.5-flash'
+    });
     return output!;
   }
 );

--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -1,6 +1,6 @@
 import { genkit } from 'genkit';
-// import { googleAI } from '@genkit-ai/googleai';
+import { googleAI } from '@genkit-ai/googleai';
 
 export const ai = genkit({
-  // plugins: [googleAI()],
+  plugins: [googleAI()],
 });


### PR DESCRIPTION
Enable Google AI plugin and specify a model for the prompt to fix a runtime error.

The error "missing `model` parameter in a `generate()` call" occurred because the `prompt()` function requires a model, but the Google AI plugin was commented out, preventing any model from being configured or used. This PR enables the plugin and explicitly sets `googleai/gemini-1.5-flash` as the model for the `getSystemOverviewFlow` prompt.